### PR TITLE
Permit minor version updates to Faraday.

### DIFF
--- a/faraday-restrict-ip-addresses.gemspec
+++ b/faraday-restrict-ip-addresses.gemspec
@@ -1,7 +1,7 @@
 require_relative 'lib/faraday/restrict_ip_addresses/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', '~>0.9.0'
+  spec.add_dependency 'faraday', '~> 0.9'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Ben Lavender"]
   spec.description = %q{Restrict the IP addresses Faraday will connect to}


### PR DESCRIPTION
From `~> 0.9.0` to `~> 0.9` for Faraday, permitting 0.15.3.